### PR TITLE
geom_alt props

### DIFF
--- a/data/856/322/17/85632217.geojson
+++ b/data/856/322/17/85632217.geojson
@@ -600,6 +600,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -642,6 +643,10 @@
     },
     "wof:country":"EH",
     "wof:country_alpha3":"ESH",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"5a142a4b86dd558940b6fbcee35bb1f4",
     "wof:hierarchy":[
         {
@@ -653,7 +658,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566586927,
+    "wof:lastmodified":1582355575,
     "wof:name":"Western Sahara",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/17/85632217.geojson
+++ b/data/856/322/17/85632217.geojson
@@ -600,7 +600,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -658,7 +657,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582355575,
+    "wof:lastmodified":1583237606,
     "wof:name":"Western Sahara",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/453/183/890453183.geojson
+++ b/data/890/453/183/890453183.geojson
@@ -419,6 +419,9 @@
     },
     "wof:country":"EH",
     "wof:created":1469052844,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"17cceae3a8fd4f7058dbb0dda778474e",
     "wof:hierarchy":[
         {
@@ -429,7 +432,7 @@
         }
     ],
     "wof:id":890453183,
-    "wof:lastmodified":1566586930,
+    "wof:lastmodified":1582355575,
     "wof:name":"La\u00e2youne / El Aai\u00fan",
     "wof:parent_id":85673941,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.