### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/576/472/9/1125764729.geojson
+++ b/data/112/576/472/9/1125764729.geojson
@@ -28,6 +28,18 @@
     "name:ara_x_variant":[
         "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u062f\u0627\u062e\u0644\u0629"
     ],
+    "name:ary_x_preferred":[
+        "\u0627\u0644\u062f\u0627\u062e\u0644\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u062f\u0627\u062e\u0644\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Dakhla"
+    ],
+    "name:azb_x_preferred":[
+        "\u062f\u0627\u062e\u0644\u0647"
+    ],
     "name:ben_x_preferred":[
         "\u09a6\u09be\u0996\u09b2\u09be"
     ],
@@ -76,6 +88,9 @@
     "name:fra_x_preferred":[
         "Dakhla"
     ],
+    "name:gle_x_preferred":[
+        "Dakhla"
+    ],
     "name:glg_x_preferred":[
         "Dakhla"
     ],
@@ -89,6 +104,9 @@
         "\u0926\u093e\u0916\u0932\u093e"
     ],
     "name:hun_x_preferred":[
+        "Dakhla"
+    ],
+    "name:ido_x_preferred":[
         "Dakhla"
     ],
     "name:ind_x_preferred":[
@@ -142,6 +160,9 @@
     "name:sin_x_preferred":[
         "\u0da9\u0d9a\u0dca\u0dbd\u0dcf"
     ],
+    "name:slk_x_preferred":[
+        "Dachla"
+    ],
     "name:spa_x_preferred":[
         "Villa Cisneros"
     ],
@@ -178,7 +199,13 @@
     "name:urd_x_variant":[
         "\u062f\u0627\u062e\u0644\u06c1"
     ],
+    "name:vec_x_preferred":[
+        "Dakhla"
+    ],
     "name:vie_x_preferred":[
+        "Dakhla"
+    ],
+    "name:war_x_preferred":[
         "Dakhla"
     ],
     "name:zho_x_preferred":[
@@ -221,7 +248,7 @@
         }
     ],
     "wof:id":1125764729,
-    "wof:lastmodified":1566586930,
+    "wof:lastmodified":1690876162,
     "wof:name":"Ad Dakhla",
     "wof:parent_id":85673951,
     "wof:placetype":"locality",

--- a/data/114/190/914/5/1141909145.geojson
+++ b/data/114/190/914/5/1141909145.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0626\u0631 \u0644\u062d\u0644\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0626\u0631 \u0644\u062d\u0644\u0648"
+    ],
     "name:ast_x_preferred":[
         "Bir Lehlu"
     ],
@@ -29,6 +32,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0456\u0440-\u041b\u0435\u043b\u0443"
+    ],
+    "name:bel_x_variant":[
+        "\u0411\u0456\u0440-\u041b\u0435\u043b\u0443"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09bf\u09b0 \u09b2\u09c7\u09b9\u09b2\u09cb\u0989"
@@ -62,6 +68,9 @@
     ],
     "name:hin_x_preferred":[
         "\u092c\u0940\u0930 \u0932\u0939\u0932\u0942"
+    ],
+    "name:hun_x_preferred":[
+        "Bir Lehlou"
     ],
     "name:ind_x_preferred":[
         "Bir Lehlou"
@@ -111,8 +120,14 @@
     "name:srd_x_preferred":[
         "Bir Lehlu"
     ],
+    "name:swa_x_preferred":[
+        "Bir Lehlou"
+    ],
     "name:swe_x_preferred":[
         "Bir Lehlou"
+    ],
+    "name:swe_x_variant":[
+        "Bir Lehlu"
     ],
     "name:tur_x_preferred":[
         "Bir Lehlu"
@@ -252,7 +267,7 @@
         }
     ],
     "wof:id":1141909145,
-    "wof:lastmodified":1636502499,
+    "wof:lastmodified":1690876162,
     "wof:name":"Bir Lehlou",
     "wof:parent_id":85681349,
     "wof:placetype":"locality",

--- a/data/421/173/611/421173611.geojson
+++ b/data/421/173/611/421173611.geojson
@@ -20,6 +20,18 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0633\u0645\u0627\u0631\u0629"
     ],
+    "name:ary_x_preferred":[
+        "\u0627\u0644\u0633\u0645\u0627\u0631\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0633\u0645\u0627\u0631\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Smara"
+    ],
+    "name:azb_x_preferred":[
+        "\u0633\u0645\u0627\u0631\u0647"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cd\u09ae\u09be\u09b0\u09be"
     ],
@@ -65,6 +77,9 @@
     "name:fra_x_preferred":[
         "Es-Semara"
     ],
+    "name:fra_x_variant":[
+        "Smara"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0acd\u0aae\u0abe\u0ab0\u0abe"
     ],
@@ -100,6 +115,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0938\u094d\u092e\u093e\u0930\u093e"
+    ],
+    "name:mlt_x_preferred":[
+        "Smara"
     ],
     "name:msa_x_preferred":[
         "Smara"
@@ -145,6 +163,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0421\u043c\u0430\u0440\u0430"
+    ],
+    "name:ukr_x_variant":[
+        "\u0415\u0441-\u0421\u0435\u043c\u0430\u0440\u0430"
     ],
     "name:urd_x_preferred":[
         "\u0633\u0645\u0627\u0631\u0627"
@@ -203,7 +224,7 @@
         }
     ],
     "wof:id":421173611,
-    "wof:lastmodified":1566586929,
+    "wof:lastmodified":1690876161,
     "wof:name":"Semara",
     "wof:parent_id":85673947,
     "wof:placetype":"locality",

--- a/data/856/322/17/85632217.geojson
+++ b/data/856/322/17/85632217.geojson
@@ -36,11 +36,23 @@
     "name:amh_x_preferred":[
         "\u121d\u12d5\u122b\u1263\u12ca \u1223\u1205\u122b"
     ],
+    "name:ami_x_preferred":[
+        "West sahara"
+    ],
+    "name:anp_x_preferred":[
+        "\u092a\u0936\u094d\u091a\u093f\u092e\u0940 \u0938\u0939\u093e\u0930\u093e"
+    ],
     "name:ara_x_preferred":[
         "\u0627\u0644\u0635\u062d\u0631\u0627\u0621 \u0627\u0644\u063a\u0631\u0628\u064a\u0629"
     ],
     "name:arg_x_preferred":[
         "Sahara Occidental"
+    ],
+    "name:arq_x_preferred":[
+        "\u0627\u0644\u0635\u062d\u0631\u0627\u0621 \u0627\u0644\u063a\u0631\u0628\u064a\u0629"
+    ],
+    "name:ary_x_preferred":[
+        "\u0627\u0644\u0635\u062d\u0631\u0627 \u0627\u0644\u063a\u0631\u0628\u064a\u0629"
     ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u0635\u062d\u0631\u0627 \u0627\u0644\u063a\u0631\u0628\u064a\u0647"
@@ -49,7 +61,14 @@
         "S\u00e1hara Occidental"
     ],
     "name:ast_x_variant":[
-        "S\u00e1\u1e25ara Occidental"
+        "S\u00e1\u1e25ara Occidental",
+        "El S\u00e1\u1e25ara Occidental"
+    ],
+    "name:avk_x_preferred":[
+        "Taltefa Saxara"
+    ],
+    "name:azb_x_preferred":[
+        "\u063a\u0631\u0628\u06cc \u0635\u062d\u0631\u0627"
     ],
     "name:aze_x_preferred":[
         "Q\u0259rbi Saxara"
@@ -59,6 +78,9 @@
     ],
     "name:bak_x_preferred":[
         "\u041a\u04e9\u043d\u0431\u0430\u0439\u044b\u0448 \u0421\u0430\u0445\u0430\u0440\u0430"
+    ],
+    "name:bar_x_preferred":[
+        "Westsahara"
     ],
     "name:bcl_x_preferred":[
         "Sulnupan na Sahara"
@@ -182,6 +204,9 @@
     "name:gla_x_preferred":[
         "Sathara an Iar"
     ],
+    "name:gle_x_preferred":[
+        "An Sah\u00e1ra Thiar"
+    ],
     "name:glg_x_preferred":[
         "S\u00e1hara Occidental"
     ],
@@ -199,6 +224,12 @@
     ],
     "name:hat_x_preferred":[
         "Sahara oksidantal"
+    ],
+    "name:hau_x_preferred":[
+        "Yammacin Sahara"
+    ],
+    "name:haw_x_preferred":[
+        "Sahara Komohana"
     ],
     "name:hbs_x_preferred":[
         "Zapadna Sahara"
@@ -223,6 +254,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0531\u0580\u0587\u0574\u057f\u0575\u0561\u0576 \u054d\u0561\u0570\u0561\u0580\u0561"
+    ],
+    "name:ido_x_preferred":[
+        "Westala Sahara"
     ],
     "name:ile_x_preferred":[
         "West-Sahara"
@@ -278,6 +312,9 @@
     "name:lad_x_preferred":[
         "Sahara Oksidental"
     ],
+    "name:lao_x_preferred":[
+        "\u0eaa\u0eb0\u0eab\u0eb2\u0ea3\u0eb2\u0e9e\u0eb2\u0e81\u0ec3\u0e95\u0ec9"
+    ],
     "name:lat_x_preferred":[
         "Sahara Occidentalis"
     ],
@@ -316,6 +353,9 @@
     ],
     "name:mon_x_preferred":[
         "\u0411\u0430\u0440\u0443\u0443\u043d \u0421\u0430\u0445\u0430\u0440"
+    ],
+    "name:mri_x_preferred":[
+        "Hah\u0101ra ki te Hau\u0101uru"
     ],
     "name:mrj_x_preferred":[
         "\u0412\u0430\u0434\u044b\u0432\u0435\u043b \u0421\u0430\u0445\u0430\u0440\u0430"
@@ -404,11 +444,17 @@
     "name:sah_x_variant":[
         "\u0410\u0440\u0495\u0430\u0430 \u0421\u0430h\u0430\u0430\u0440\u0430"
     ],
+    "name:sat_x_preferred":[
+        "\u1c6f\u1c5f\u1c6a\u1c6e \u1c65\u1c5f\u1c66\u1c5f\u1c68\u1c5f"
+    ],
     "name:scn_x_preferred":[
         "Sahara Uccidintali"
     ],
     "name:sco_x_preferred":[
         "Wastren Sahara"
+    ],
+    "name:shn_x_preferred":[
+        "\u101e\u1083\u1087\u1081\u1083\u1087\u101b\u1083\u1087 \u1015\u103d\u1010\u103a\u1038\u101d\u107c\u103a\u1038\u1010\u1030\u1075\u103a\u1038"
     ],
     "name:sin_x_preferred":[
         "\u0db6\u0da7\u0dc4\u0dd2\u0dbb \u0dc3\u0dc4\u0dbb\u0dcf\u0dc0"
@@ -424,6 +470,12 @@
     ],
     "name:sme_x_preferred":[
         "Oarje-Sah\u00e1ra"
+    ],
+    "name:snd_x_preferred":[
+        "\u0645\u063a\u0631\u0628\u064a \u0635\u062d\u0627\u0631\u0627"
+    ],
+    "name:sot_x_preferred":[
+        "Western Sahara"
     ],
     "name:spa_x_preferred":[
         "Sahara Occidental"
@@ -451,11 +503,17 @@
         "Spanska Sahara",
         "V\u00e4stsahara"
     ],
+    "name:szy_x_preferred":[
+        "West sahara"
+    ],
     "name:tam_x_preferred":[
         "\u0bae\u0bc7\u0bb1\u0bcd\u0b95\u0bc1 \u0b9a\u0b95\u0bbe\u0bb0\u0bbe"
     ],
     "name:tat_x_preferred":[
         "\u041a\u04e9\u043d\u0431\u0430\u0442\u044b\u0448 \u0421\u0430\u0445\u0430\u0440\u0430"
+    ],
+    "name:tay_x_preferred":[
+        "West sahara"
     ],
     "name:tel_x_preferred":[
         "\u0c35\u0c46\u0c38\u0c4d\u0c1f\u0c30\u0c4d\u0c28\u0c4d \u0c38\u0c39\u0c3e\u0c30\u0c3e"
@@ -469,6 +527,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e27\u0e2a\u0e40\u0e17\u0e34\u0e23\u0e4c\u0e19\u0e2a\u0e30\u0e2e\u0e32\u0e23\u0e32"
     ],
+    "name:trv_x_preferred":[
+        "Western Sahara"
+    ],
     "name:tso_x_preferred":[
         "Western Sahara"
     ],
@@ -477,6 +538,9 @@
     ],
     "name:uig_x_preferred":[
         "\u063a\u06d5\u0631\u0628\u0649\u064a \u0633\u0627\u06be\u0627\u0631\u0627"
+    ],
+    "name:uig_x_variant":[
+        "\u063a\u06d5\u0631\u0628\u0649\u064a \u0633\u06d5\u06be\u0631\u0627"
     ],
     "name:ukr_x_preferred":[
         "\u0417\u0430\u0445\u0456\u0434\u043d\u0430 \u0421\u0430\u0445\u0430\u0440\u0430"
@@ -508,6 +572,9 @@
     "name:wol_x_preferred":[
         "Sahara gu Sowwu"
     ],
+    "name:wuu_x_preferred":[
+        "\u897f\u6492\u54c8\u62c9"
+    ],
     "name:xmf_x_preferred":[
         "\u10d1\u10df\u10d0\u10d3\u10d0\u10da\u10d8 \u10e1\u10d0\u10f0\u10d0\u10e0\u10d0"
     ],
@@ -534,6 +601,9 @@
     ],
     "name:zho_yue_x_preferred":[
         "\u897f\u6492\u54c8\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "ISahara lasentshonalanga"
     ],
     "ne:abbrev":"W. Sah.",
     "ne:abbrev_len":7,
@@ -743,7 +813,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1636502498,
+    "wof:lastmodified":1690876161,
     "wof:name":"Western Sahara",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.