### PR TITLE
eh concordances, placetype local, and more

### DIFF
--- a/data/856/322/17/85632217.geojson
+++ b/data/856/322/17/85632217.geojson
@@ -787,6 +787,7 @@
         "gaul:id":"268",
         "gp:id":23424990,
         "hasc:id":"EH",
+        "iso:code":"EH",
         "itu:id":"AOE",
         "m49:code":"732",
         "marc:id":"ss",
@@ -796,6 +797,7 @@
         "qs_pg:id":1087778,
         "wd:id":"Q6250"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85681349
     ],
@@ -817,7 +819,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1694639668,
+    "wof:lastmodified":1695881328,
     "wof:name":"Western Sahara",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/813/49/85681349.geojson
+++ b/data/856/813/49/85681349.geojson
@@ -583,8 +583,10 @@
         "gn:id":2461445,
         "gp:id":23424990,
         "hasc:id":"EH",
+        "iso:code_pseudo":"EH",
         "qs_pg:id":1087778
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         85632217
     ],
@@ -604,7 +606,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884286,
     "wof:name":"Western Sahara",
     "wof:parent_id":85632217,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.